### PR TITLE
Undefined yylex() function fix

### DIFF
--- a/phoebe-lib/libphoebe/phoebe_constraints.grm.y
+++ b/phoebe-lib/libphoebe/phoebe_constraints.grm.y
@@ -11,6 +11,7 @@
 /*#include "phoebe_constraints.lng.h"*/
 #include "phoebe_parameters.h"
 
+extern int yylex(void);
 extern int yyerror (const char *str);
 extern int intern_constraint_add_to_table (PHOEBE_ast *ast);
 %}


### PR DESCRIPTION
Macs 11+ do not seem to support implicit declarations of functions; yylex is now explicitly defined in the yacc file.

Fixes #20 